### PR TITLE
markdown_list_numbering

### DIFF
--- a/library/src/main/kotlin/com/devbrackets/android/androidmarkup/parser/markdown/MarkdownDocument.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/androidmarkup/parser/markdown/MarkdownDocument.kt
@@ -66,7 +66,7 @@ open class MarkdownDocument : MarkupDocument {
 
         val lines = tempBuilder.toString().orEmpty().split("\n")
         for (i in lines.indices) {
-            builder.append(ORDERED_LIST_ITEM)
+            builder.append(i + 1).append(". ")
             builder.append(lines[i])
             if (i != lines.size -1) {
                 builder.appendln()

--- a/library/src/main/kotlin/com/devbrackets/android/androidmarkup/parser/markdown/MarkdownDocument.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/androidmarkup/parser/markdown/MarkdownDocument.kt
@@ -115,7 +115,6 @@ open class MarkdownDocument : MarkupDocument {
     companion object {
         const val BOLD_TAG: String = "**"
         const val ITALICS_TAG: String = "_"
-        const val ORDERED_LIST_ITEM = "0. "
         const val UNORDERED_LIST_ITEM = "* "
 
         //Also known as ASCII punctuation characters


### PR DESCRIPTION
Ordered lists are now numbered in markdown instead of using '0. ' for all.	